### PR TITLE
Fix not working on components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-spec",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A missing schematics for creating missing / recreating Angular 6+ specs",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/src/spec/index.js
+++ b/src/spec/index.js
@@ -54,6 +54,7 @@ function default_1(options) {
             throw new schematics_1.SchematicsException(ex);
         }
         options.name = name;
+		options.type = type;
         options.path = parsedPath.path;
         const schematicsPath = require.resolve(`@schematics/angular/${type}/index.js`).replace(/index\.js$/, 'files');
         const targetPath = `${parsedPath.path}/${name}.${type}.ts`;

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -75,6 +75,7 @@ export default function (options: Options): Rule {
     }
 
     options.name = name;
+    options.type = type;
     options.path = parsedPath.path;
 
     const schematicsPath = require.resolve(`@schematics/angular/${type}/index.js`).replace(/index\.js$/, 'files');

--- a/src/spec/schema.json
+++ b/src/spec/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsSpec",
+  "$id": "SchematicsSpec",
   "title": "Angular Spec Options Schema",
   "type": "object",
   "properties": {

--- a/src/specs/index.js
+++ b/src/specs/index.js
@@ -47,6 +47,7 @@ function default_1(options) {
                         // important for windows to get the relative path, otherwise schematics becomes crazy when sees C:\bla\bla things
                         const relativeSchematicsPath = nodePath.relative(__dirname, utils_1.getStandardSchematicPath(fdesc.type));
                         options.name = fdesc.name;
+                        options.type = fdesc.type;
                         options.path = fdesc.path;
                         templateSources.push(schematics_1.apply(schematics_1.url(relativeSchematicsPath), [
                             schematics_1.filter(path => path.endsWith('.spec.ts.template')),

--- a/src/specs/index.ts
+++ b/src/specs/index.ts
@@ -58,6 +58,7 @@ export default function (options: Options): Rule {
             const relativeSchematicsPath = nodePath.relative(__dirname, getStandardSchematicPath(fdesc.type));
 
             options.name = fdesc.name;
+            options.type = fdesc.type;
             options.path = fdesc.path;
 
             templateSources.push(

--- a/src/specs/schema.json
+++ b/src/specs/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsSpec",
+  "$id": "SchematicsSpec",
   "title": "Angular Spec Options Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
There were 2 different issues i fixed with this update:

- 'id' needed to be updated to '$id' in schemas, to comply with current standards. This fixes working in Angular 13 projects.
- Component specs creation now needs new data "type". This information was already on the workflow  but was not sent to the preset applier.

Package currently working in Angular 13.1.2