### PR TITLE
Fix deprecation warning, standalone missing error, and 'index.js.js'

### DIFF
--- a/src/spec/index.js
+++ b/src/spec/index.js
@@ -56,7 +56,7 @@ function default_1(options) {
         options.name = name;
 		options.type = type;
         options.path = parsedPath.path;
-        const schematicsPath = require.resolve(`@schematics/angular/${type}/index.js`).replace(/index\.js$/, 'files');
+        const schematicsPath = require.resolve(`@schematics/angular/${type}/index`).replace(/index\.js$/, 'files');
         const targetPath = `${parsedPath.path}/${name}.${type}.ts`;
         if (!host.exists(targetPath) && !options.ignoreTargetNotFound) {
             throw new schematics_1.SchematicsException(`Target file ${targetPath} is not existing`);

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -78,7 +78,7 @@ export default function (options: Options): Rule {
     options.type = type;
     options.path = parsedPath.path;
 
-    const schematicsPath = require.resolve(`@schematics/angular/${type}/index.js`).replace(/index\.js$/, 'files');
+    const schematicsPath = require.resolve(`@schematics/angular/${type}/index`).replace(/index\.js$/, 'files');
 
     const targetPath = `${parsedPath.path}/${name}.${type}.ts`;
 

--- a/src/spec/schema.json
+++ b/src/spec/schema.json
@@ -12,6 +12,12 @@
         "index": 0
       }
     },
+    "standalone": {
+      "description": "Whether the generated component is standalone.",
+      "type": "boolean",
+      "default": false,
+      "x-user-analytics": 15
+    },
     "path": {
       "type": "string",
       "format": "path",

--- a/src/spec/schema.json
+++ b/src/spec/schema.json
@@ -15,6 +15,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+       },
       "description": "The path to create the spec.",
       "visible": false
     },

--- a/src/specs/schema.json
+++ b/src/specs/schema.json
@@ -12,6 +12,12 @@
         "index": 0
       }
     },
+    "standalone": {
+      "description": "Whether the generated component is standalone.",
+      "type": "boolean",
+      "default": false,
+      "x-user-analytics": 15
+    },
     "path": {
       "type": "string",
       "format": "path",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,22 +1,26 @@
-import { SupportedTypes } from './supported-types';
+import { SupportedTypes } from "./supported-types";
 
 export function describeFile(fullPath: string) {
-  const [, name, type] = (fullPath.replace(/\.ts$/, '').match(/(.*)\.([^.]+)$/) || [null, null, null]) as string[];
+  const [, name, type] = (fullPath
+    .replace(/\.ts$/, "")
+    .match(/(.*)\.([^.]+)$/) || [null, null, null]) as string[];
 
   if (!name || !type) {
     return null;
   }
 
-  const path = name.replace(/[^/\\]*$/, '');
+  const path = name.replace(/[^/\\]*$/, "");
 
   return {
-    path: path.replace(/[^/\\]$/, ''),
-    name: name.replace(path, ''),
+    path: path.replace(/[^/\\]$/, ""),
+    name: name.replace(path, ""),
     type,
-    supported: SupportedTypes.includes(type)
+    supported: SupportedTypes.includes(type),
   };
 }
 
 export function getStandardSchematicPath(type: string) {
-  return require.resolve(`@schematics/angular/${type}/index.js`).replace(/index\.js$/, 'files');
+  return require
+    .resolve(`@schematics/angular/${type}/index`)
+    .replace(/index\.js$/, "files");
 }


### PR DESCRIPTION
new spec - angular cli shows error
`cannot find module @schematics\....\index.js.js`
removed '.js' from index.js
![Screenshot 2022-12-09 195206](https://user-images.githubusercontent.com/82303541/206762945-ae00355d-c8af-4fcd-bd77-af2acdcb4389.png)


deprecation warning - added path options to schema, in order to supress warning.
![Screenshot 2022-12-09 195254](https://user-images.githubusercontent.com/82303541/206763124-30e298ab-f877-4f17-8819-c1ac756a2971.png)
related to #16 
